### PR TITLE
refactor (Metrics): Drop the application prefix on Metrics

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,19 +47,18 @@ The following is the design spec for each metric. As of now, none are implemente
 
 | Metric                               | Implemented | What it means                                                           | Type of metric | Labels       | 
 |--------------------------------------|-------------| ------------------------------------------------------------------------|----------------|--------------|
-| magento_cron_execution_timestamp     | Yes         | The unix timestamp of the last cron execution                           | Gauge          |              |
-| magento_cron_queue_length            |             | The number of cron jobs that are due for processing in Magento          | Guadge (0,)    |              |
-| magento_indexer_status_ready         |             | Whether the indexer is "ready", or needs reindexing                     | Gaudge (0,1)   | indexer_code |
-| magento_indexer_reindex_total        | Yes         | A count of the number of times the indexer has been reindexed           | Counter        | indexer_code |
-| magento_cache_status_enabled         |             | Whether the cache is enabled and valid                                  | Guadge (0,1)   | cache_type   |
-| magento_cache_flush_total            | Yes         | A count of the number of cache flushes                                  | Counter        | cache_type   |
-| magento_orders_completed_total       |             | A count of the number of completed orders                               | Counter        | store_code   |
-| magento_orders_shipped_total         |             | A count of the number of shipped orders                                 | Counter        | store_code   |
-| magento_orders_returns_total         |             | A count of the number of returned orders                                | Counter        | store_code   |
-| magento_uncaught_exceptions_total    |             | A count of the number of uncaught exceptions                            | Counter        |              |
-| magento_gift_card_usage_total        |             | A count of the usage of gift cards                                      | Counter        |              |
-| magento_customer_login_total         |             | A count of the number of times a Magento user has logged in             | Counter        | store_code   |
-| magento_promotion_code_usage_total   |             | A count of the number of times promo codes have been used               | Counter        | code         |
+| mage_cron_execution_timestamp        | Yes         | The unix timestamp of the last cron execution                           | Gauge          |              |
+| mage_cron_queue_length               |             | The number of cron jobs that are due for processing in Magento          | Guadge (0,)    |              |
+| mage_indexer_status_ready            |             | Whether the indexer is "ready", or needs reindexing                     | Gaudge (0,1)   | indexer_code |
+| mage_indexer_reindex_total           | Yes         | A count of the number of times the indexer has been reindexed           | Counter        | indexer_code |
+| mage_cache_status_enabled            |             | Whether the cache is enabled and valid                                  | Guadge (0,1)   | cache_type   |
+| mage_cache_flush_total               | Yes         | A count of the number of cache flushes                                  | Counter        | cache_type   |
+| mage_sales_orders_completed_total    |             | A count of the number of completed orders                               | Counter        | store_code   |
+| mage_sales_orders_shipped_total      |             | A count of the number of shipped orders                                 | Counter        | store_code   |
+| mage_sales_orders_returned_total     |             | A count of the number of returned orders                                | Counter        | store_code   |
+| mage_core_uncaught_exceptions_total  |             | A count of the number of uncaught exceptions                            | Counter        |              |
+| mage_customer_login_total            |             | A count of the number of times a Magento user has logged in             | Counter        | store_code   |
+| mage_salesrule_coupon_usage_total    |             | A count of the number of times promo codes have been used               | Counter        | code         |
 
 ### Additional possible metric candidates
 

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ In the observer class create a push-metric call utilizing the handy metric facto
             ->getCounter(
                 '<metric_name>',
                 [
+                    'metric_namespace' => '<vendor_extension>,'
                     'metric_help' => '<Description of the metric>',
                     'label_titles' => ['<label>']
                 ]

--- a/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Abstract.php
+++ b/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Abstract.php
@@ -25,18 +25,52 @@
  */
 abstract class Sitewards_Prometheus_Model_Metrics_Abstract
 {
-    const S_ARG_KEY_METRIC_NAME  = 'metric_name';
-    const S_ARG_KEY_METRIC_HELP  = 'metric_help';
-    const S_ARG_KEY_LABEL_TITLES = 'label_titles';
-
-    const S_METRIC_NAMESPACE = 'magento';
+    const S_ARG_KEY_METRIC_NAME      = 'metric_name';
+    const S_ARG_KEY_METRIC_HELP      = 'metric_help';
+    const S_ARG_KEY_LABEL_TITLES     = 'label_titles';
+    const S_ARG_KEY_METRIC_NAMESPACE = 'metric_namespace';
 
     const S_TYPE_GAUGE   = 'gauge';
     const S_TYPE_COUNTER = 'counter';
 
-    protected $sMetricType  = '';
-    protected $sMetricName  = '';
-    protected $sMetricHelp  = '';
+    /**
+     * The metric type. Can be one of:
+     *
+     * - Gauge
+     * - Counter
+     *
+     * @var string
+     */
+    protected $sMetricType = '';
+
+    /**
+     * The name of the metric. Should be a short descriptive string, of the form "foo_bar". Check out
+     * https://prometheus.io/docs/practices/naming/ for details on naming metrics.
+     *
+     * @var string
+     */
+    protected $sMetricName = '';
+
+    /**
+     * A text description that indicates what the metric represents
+     *
+     * @var string
+     */
+    protected $sMetricHelp = '';
+
+    /**
+     * The library that is exposing the metrics. Use the module name; for example, "sitewards_prometheus"
+     *
+     * @var string
+     */
+    protected $sMetricNamespace = '';
+
+    /**
+     * Labels that are being applied to the metric. Check out
+     * https://prometheus.io/docs/practices/naming/ for details on labels.
+     *
+     * @var array
+     */
     protected $aLabelTitles = [];
 
     /**
@@ -49,6 +83,7 @@ abstract class Sitewards_Prometheus_Model_Metrics_Abstract
     protected function _checkArgs(array $aArgs)
     {
         $aArgKeys = [
+            self::S_ARG_KEY_METRIC_NAMESPACE,
             self::S_ARG_KEY_METRIC_NAME,
             self::S_ARG_KEY_METRIC_HELP,
             self::S_ARG_KEY_LABEL_TITLES

--- a/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Counter.php
+++ b/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Counter.php
@@ -29,26 +29,28 @@ class Sitewards_Prometheus_Model_Metrics_Counter extends Sitewards_Prometheus_Mo
      *
      * @param array $aOptions An array of the form
      *                        [
-     *                          'metric_name'  => The name of the metric. Of the format vendor_extension_process_type.
-     *                                            For example sitewards_prometheus_apcu_total,
-     *                          'metric_help'  => The help text to provide some context on the metric for debugging
-     *                          'label_titles' => [
+     *                          'metric_namespace' => The module name. For example, sitewards_prometheus
+     *                          'metric_name'      => The name of the metric. Of the format process_type. For example
+     *                                                apcu_total
+     *                          'metric_help'      => The help text to provide some context on the metric for debugging
+     *                          'label_titles'     => [
      *                              'label_a',
      *                              'label_b'
      *                           ]
      *                        ]
      */
-    public function __construct($aOptions)
+    public function __construct(array $aOptions)
     {
         $this->_checkArgs($aOptions);
 
-        $this->sMetricName  = $aOptions[self::S_ARG_KEY_METRIC_NAME];
-        $this->sMetricHelp  = $aOptions[self::S_ARG_KEY_METRIC_HELP];
-        $this->aLabelTitles = $aOptions[self::S_ARG_KEY_LABEL_TITLES];
+        $this->sMetricNamespace = $aOptions[self::S_ARG_KEY_METRIC_NAMESPACE];
+        $this->sMetricName      = $aOptions[self::S_ARG_KEY_METRIC_NAME];
+        $this->sMetricHelp      = $aOptions[self::S_ARG_KEY_METRIC_HELP];
+        $this->aLabelTitles     = $aOptions[self::S_ARG_KEY_LABEL_TITLES];
 
         $this->getResource()
             ->registerCounter(
-                self::S_METRIC_NAMESPACE,
+                $this->sMetricNamespace,
                 $this->sMetricName,
                 $this->sMetricHelp,
                 $this->aLabelTitles
@@ -65,7 +67,7 @@ class Sitewards_Prometheus_Model_Metrics_Counter extends Sitewards_Prometheus_Mo
     public function increment($iValue = 1, $aLabelValues = [])
     {
         $this->getResource()
-            ->getCounter(self::S_METRIC_NAMESPACE, $this->sMetricName)
+            ->getCounter($this->sMetricNamespace, $this->sMetricName)
             ->incBy($iValue, $aLabelValues);
     }
 }

--- a/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Gauge.php
+++ b/src/app/code/community/Sitewards/Prometheus/Model/Metrics/Gauge.php
@@ -29,26 +29,28 @@ class Sitewards_Prometheus_Model_Metrics_Gauge extends Sitewards_Prometheus_Mode
      *
      * @param array $aOptions An array of the form
      *                        [
-     *                          'metric_name'  => The name of the metric. Of the format vendor_extension_process_type.
-     *                                            For example sitewards_prometheus_apcu_total,
-     *                          'metric_help'  => The help text to provide some context on the metric for debugging
-     *                          'label_titles' => [
+     *                          'metric_namespace' => The module name. For example, sitewards_prometheus
+     *                          'metric_name'      => The name of the metric. Of the format process_type. For example
+     *                                                apcu_total
+     *                          'metric_help'      => The help text to provide some context on the metric for debugging
+     *                          'label_titles'     => [
      *                              'label_a',
      *                              'label_b'
      *                           ]
      *                        ]
      */
-    public function __construct($aOptions)
+    public function __construct(array $aOptions)
     {
         $this->_checkArgs($aOptions);
 
-        $this->sMetricName  = $aOptions[self::S_ARG_KEY_METRIC_NAME];
-        $this->sMetricHelp  = $aOptions[self::S_ARG_KEY_METRIC_HELP];
-        $this->aLabelTitles = $aOptions[self::S_ARG_KEY_LABEL_TITLES];
+        $this->sMetricNamespace = $aOptions[self::S_ARG_KEY_METRIC_NAMESPACE];
+        $this->sMetricName      = $aOptions[self::S_ARG_KEY_METRIC_NAME];
+        $this->sMetricHelp      = $aOptions[self::S_ARG_KEY_METRIC_HELP];
+        $this->aLabelTitles     = $aOptions[self::S_ARG_KEY_LABEL_TITLES];
 
         $this->getResource()
             ->registerGauge(
-                self::S_METRIC_NAMESPACE,
+                $this->sMetricNamespace,
                 $this->sMetricName,
                 $this->sMetricHelp,
                 $this->aLabelTitles
@@ -64,7 +66,7 @@ class Sitewards_Prometheus_Model_Metrics_Gauge extends Sitewards_Prometheus_Mode
     public function update($fValue, array $aLabelValues = [])
     {
         $this->getResource()
-            ->getGauge(self::S_METRIC_NAMESPACE, $this->sMetricName)
+            ->getGauge($this->sMetricNamespace, $this->sMetricName)
             ->set($fValue, $aLabelValues);
     }
 }

--- a/src/app/code/community/Sitewards/Prometheus/Model/Observer.php
+++ b/src/app/code/community/Sitewards/Prometheus/Model/Observer.php
@@ -37,9 +37,10 @@ class Sitewards_Prometheus_Model_Observer
     {
         Mage::getModel('sitewards_prometheus/metricFactory')
             ->getGauge(
-                'cron_execution_timestamp',
+                'execution_timestamp',
                 [
-                    'metric_help' => 'The last time (in unix time) Cron was executed'
+                    'metric_namespace' => 'mage_cron',
+                    'metric_help'      => 'The last time (in unix time) Cron was executed'
                 ]
             )
             ->update(now());
@@ -56,10 +57,11 @@ class Sitewards_Prometheus_Model_Observer
     {
         Mage::getModel('sitewards_prometheus/metricFactory')
             ->getCounter(
-                'cache_flush_total',
+                'flush_total',
                 [
-                    'metric_help' => 'The total number of times the cache has been flushed.',
-                    'label_titles' => ['type']
+                    'metric_namespace' => 'mage_cache',
+                    'metric_help'      => 'The total number of times the cache has been flushed.',
+                    'label_titles'     => ['type']
                 ]
             )
             ->increment(1, [$oEvent->getType()]);
@@ -80,10 +82,11 @@ class Sitewards_Prometheus_Model_Observer
 
         Mage::getModel('sitewards_prometheus/metricFactory')
             ->getCounter(
-                'indexer_reindex_total',
+                'reindex_total',
                 [
-                    'metric_help' => 'The total number of times the index has been reset',
-                    'label_titles' => ['type']
+                    'metric_namespace' => 'mage_indexer',
+                    'metric_help'      => 'The total number of times the index has been reset',
+                    'label_titles'     => ['type']
                 ]
             )
             ->increment(1, [$sCode]);


### PR DESCRIPTION
Brian Brazil indicated in the talk "So you want to write an exporter"
that, ideally, metrics should be named for the library that they're
exporting metrics from rather than the application. Ref:

https://youtu.be/KXq5ibSj2qA

The application should be the job_label.